### PR TITLE
[t-mr1] BoardConfig: move bootconfig data to cmdline

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -26,7 +26,7 @@ $(warning Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)", using defa
 endif
 
 # Kernel cmdline
-BOARD_BOOTCONFIG += androidboot.hardware=pdx235
+BOARD_KERNEL_CMDLINE += androidboot.hardware=pdx235
 BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx235
 
 # FB console


### PR DESCRIPTION
No bootconfig on Zambezi.