### PR TITLE
[v-mr1] aosp_xqdc54: Set preferred network type to NR/LTE/WCDMA/GSM

### DIFF
--- a/aosp_xqdc54.mk
+++ b/aosp_xqdc54.mk
@@ -16,7 +16,7 @@
 PRODUCT_DEVICE_DS := true
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.telephony.default_network=9,9
+    ro.telephony.default_network=26,26
 
 TARGET_KERNEL_CONFIG := aosp_zambezi_pdx235_defconfig
 


### PR DESCRIPTION
The device supports the 5G network, so set the preferred
network type to NR/LTE/WCDMA/GSM. In the absence of 3G
coverage, LTE will be used, and in the absence of LTE, 3G
will be used, and so on.

The value for a specific combo can be found at:
https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-15.0.0_r36/telephony/java/com/android/internal/telephony/RILConstants.java